### PR TITLE
Issue1: loadroot.py fixed

### DIFF
--- a/devel/loadroot.py
+++ b/devel/loadroot.py
@@ -1,19 +1,19 @@
 from util import check_if_dir_exist
 import os
+import re
 
 def loadroot(env) :
-	OSENV  = os.environ
-	ROOTSYS = OSENV['ROOTSYS']
+
+	ROOTSYS = os.environ.get('ROOTSYS')
 	check_if_dir_exist('ROOTSYS')
 	if env['SHOWENV'] == "1":
 		print "Loading ROOT software from ", ROOTSYS
 
 	inc_path = []
 
-	if env['PLATFORM'] == 'posix':
+	if env['PLATFORM'] == 'posix' or env['PLATFORM'] == 'darwin':
 		inc_path = os.popen('$ROOTSYS/bin/root-config --incdir').readline()
-	if env['PLATFORM'] == 'darwin':
-		inc_path = os.popen('$ROOTSYS/bin/root-config --incdir').readline()
+
 	# on Windows there is no script
 	# Have to do it by hand
 	if env['PLATFORM'] == 'win32':
@@ -23,27 +23,20 @@ def loadroot(env) :
 
 	rootlibs = []
 	root_config_libs = []
-	if env['PLATFORM'] == 'posix':
-		root_config_libs = os.popen('$ROOTSYS/bin/root-config --glibs').readline()[:-1].split()
-	if env['PLATFORM'] == 'darwin':
-		root_config_libs = os.popen('$ROOTSYS/bin/root-config --glibs').readline()[:-1].split()
+	if env['PLATFORM'] == 'posix' or env['PLATFORM'] == 'darwin':
+		root_config_libs = os.popen('$ROOTSYS/bin/root-config --glibs').readline().rstrip().split()
+
 	# on Windows there is no script
 	# Have to do it by hand
 	# Do a showenv on Linux/Darwin and copy here
 	if env['PLATFORM'] == 'win32':
 		rootlibs = ['libCore', 'libCint', 'libRIO', 'libNet', 'libHist', 'libGraf', 'libGraf3d', 'libGpad', 'libTree', 'libRint', 'libPostscript', 'libMatrix', 'libPhysics', 'libMathCore', 'libThread', 'libGui']
 
-	for l in root_config_libs:
-		if l[:2] == '-l':
-			rootlibs += [l[2:]]
+        # This filters out all the "-lxxx" parts of the root_config_libs
+	rootlibs += [ x for x in root_config_libs if re.match('-l',x) ]
 
-
-	if env['PLATFORM'] == 'posix':
-		env.Append(LIBPATH = [ROOTSYS + '/lib'])
-	if env['PLATFORM'] == 'darwin':
-		env.Append(LIBPATH = [ROOTSYS + '/lib'])
-	if env['PLATFORM'] == 'win32':
-		env.Append(LIBPATH = [ROOTSYS + '\lib'])
+        # This grabs the "-L" part of the root_config_libs
+	env.Append(LIBPATH = [ x for x in root_config_libs  if re.match('-L',x) ] )
 
 	if env['SHOWENV'] == "1":
 		print "ROOT include path: ", inc_path


### PR DESCRIPTION
Redo: Fixup loadroot.py: filter root-config --libs for -L and -l parts; also replace [:-1] with .rstrip() which is safer, os.environ.get() instead of getting the whole environment, combine if statements if the following code is identical.

This is now working. Tested on Linux Centos6.7 and Mac OS X 10.11
