### PR TITLE
fix: `loadgeant4.py` cannot find headers if "geant4" not in path name

### DIFF
--- a/loadgeant4.py
+++ b/loadgeant4.py
@@ -27,7 +27,7 @@ def loadgeant4(env, OSENV) :
 		spl = s.split()
 		for ss in spl:
 			# only add if it's a g4 library
-			if 'geant4' in ss:
+			if 'Geant4' in ss:
 				validg4incs.append('-I'+ss);
 
 	# geant4 had this additional flag.


### PR DESCRIPTION
Instead, search for `Geant4` rather than `geant4`, because for version 10+, headers are (by default) installed to `<PREFIX>/include/Geant4`.